### PR TITLE
Add esmpy to support xesmf at NCI

### DIFF
--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -23,7 +23,7 @@ requirements:
     host:
         - python
         - numpy
-        - krb5
+        - krb5=1.17.1
     run:
         - python
         - numpy

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -23,18 +23,17 @@ requirements:
     host:
         - python
         - numpy
-        - krb5=1.17.1
+        - krb5
     run:
         - python
         - numpy
+        - openssl
 
 test:
     imports:
         - ESMF
 
 about:
-    home: http://www.earthsystemmodeling.org/esmf_releases/public/ESMF_8_0_0/esmpy_doc/html/index.html
-
     home: https://www.earthsystemcog.org/projects/esmpy/
     license: The University of Illinois/NCSA
     license_file: LICENSE

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -26,13 +26,14 @@ requirements:
     run:
         - python
         - numpy
-        - openssl
+        - krb5>=1.18.2
+
 
 test:
-    requires:
-        - openssl
-    imports:
-        - ESMF
+    commands:
+        - python -v -c 'import ESMF'
+          # imports:
+          # - ESMF
 
 about:
     home: https://www.earthsystemcog.org/projects/esmpy/

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -30,6 +30,8 @@ requirements:
         - openssl
 
 test:
+    requires:
+        - openssl
     imports:
         - ESMF
 

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -1,0 +1,41 @@
+{% set version = "8.0.1" %}
+{% set ver = version.replace(".", "_") %}
+{% set build = 0 %}
+
+package:
+    name: esmpy
+    version: {{ version }}
+
+source:
+    url: https://github.com/esmf-org/esmf/archive/ESMF_{{ ver }}/esmf_{{ ver }}_src.tar.gz
+    sha256: 9172fb73f3fe95c8188d889ee72fdadb4f978b1d969e1d8e401e8d106def1d84
+
+build:
+    number: {{ build }}
+    script: |
+        cd src/addon/ESMPy
+        {{ PYTHON }} setup.py build --ESMFMKFILE=/apps/esmf/{{ version }}/lib/esmf.mk
+        {{ PYTHON }} setup.py install
+    string: gadi
+    noarch: python
+
+requirements:
+    host:
+        - python
+        - numpy
+        - krb5
+    run:
+        - python
+        - numpy
+
+test:
+    imports:
+        - ESMF
+
+about:
+    home: http://www.earthsystemmodeling.org/esmf_releases/public/ESMF_8_0_0/esmpy_doc/html/index.html
+
+    home: https://www.earthsystemcog.org/projects/esmpy/
+    license: The University of Illinois/NCSA
+    license_file: LICENSE
+    summary: ESMPy is a Python interface to the Earth System Modeling Framework (ESMF) regridding utility. ESMPy build against NCI ESMF install.

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -23,7 +23,6 @@ requirements:
     host:
         - python
         - numpy
-        - krb5
     run:
         - python
         - numpy

--- a/esmpy/meta.yaml
+++ b/esmpy/meta.yaml
@@ -23,17 +23,14 @@ requirements:
     host:
         - python
         - numpy
+        - krb5 =1.17.*
     run:
         - python
         - numpy
-        - krb5>=1.18.2
-
-
+        - {{ pin_compatible('krb5', max_pin='x.x') }}
 test:
-    commands:
-        - python -v -c 'import ESMF'
-          # imports:
-          # - ESMF
+    imports:
+        - ESMF
 
 about:
     home: https://www.earthsystemcog.org/projects/esmpy/


### PR DESCRIPTION
Closes #5 

First try using meta.yaml from Scott and some additions based on conda-forge feedstock

https://github.com/conda-forge/esmpy-feedstock/blob/master/recipe/meta.yaml